### PR TITLE
feat: add handlers for password restriction configurations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,25 +28,77 @@ Adding a Content Restrictions Component to a course unit
 From Studio, you can add the Content Restrictions Component to a course unit.
 
 1. Click on the **Advanced** button in **Add New Component**.
-2. Select **Content Restrictions** from the list.
+
+   .. image:: https://github.com/eduNEXT/xblock-content-restrictions/assets/64440265/b0ee88bb-f3d3-40da-ba4d-281c3efbabb6
+      :alt: Open Advanced Components
+
+2. Select **Content With Access Restrictions** from the list.
+
+   .. image:: https://github.com/eduNEXT/xblock-content-restrictions/assets/64440265/4e191109-37ca-458a-b338-32d5b1a84cd3
+      :alt: Select Content Restrictions Component
+
 3. Configure the component as needed.
 
-Four restriction options can be applied to the content:
 
-- **No Restriction**: The content is always available.
-- **IP Whitelist**: The content is only available to users with an IP address that matches the specified list. For this restriction, you need to specify a list of IP addresses.
-- **Password**: The content is only available to users who enter the specified password. For this restriction, you need to specify a password.
-- **Secure Exam Browser (SEB)**: The content is only available to users who access the course using the Secure Exam Browser.
+View from the Learning Management System (CMS)
+**********************************************
+
+Password Restriction
+--------------------
+
+When you select the Password restriction option, you need to specify a password that the learner must enter to access the content.
+Specify the password in the **Password** field in the Content Restrictions component configuration. The password is case-sensitive.
+After publishing the unit with the Content Restrictions component, the learner will see a message indicating that the content is restricted and will be prompted to enter the password to access the content.
+When the learner enters the correct password, the content will be displayed.
+
+There are the available configuration options for the Password restriction:
+
+- **Password Restriction**: Enable or disable the password restriction. If disabled, the other configuration options will be ignored.
+- **Password**: The password that the learner must enter to access the content.
+- **Password Explanation Text**: The text that will be displayed to the learner to explain how to access the content.
+- **Incorrect Password Explanation Text**: The text that will be displayed to the learner when the entered password is incorrect.
+
+Here is how the Content Restrictions component looks in the Author View:
+
+   .. image:: https://github.com/eduNEXT/xblock-content-restrictions/assets/64440265/5f9e73d0-4def-41bd-b3ab-ffae1ec958b3
+      :alt: Author view for component
+
+When accessing the component by selecting the **view** button, you will see the list of children components that are restricted by the Content Restrictions component.
+
+   .. image:: https://github.com/eduNEXT/xblock-content-restrictions/assets/64440265/e8dedf11-4e04-4592-8d8f-a23a4db7952a
+      :alt: View of the component
+
+Here is an example of a Content Restrictions component with a Problem component as a child:
+
+    .. image:: https://github.com/eduNEXT/xblock-content-restrictions/assets/64440265/724a5a32-1488-41e6-b52d-236c53af8179
+       :alt: Example of a Content Restrictions component with a Problem component as a child
 
 These restrictions are applied to children in the Content Restrictions component. So in the Author View, you can add
-any other component as a child of the Content Restrictions component and the restrictions will be applied to that component.
-
+any other component as a child of the Content Restrictions component and the restrictions will be applied to those components.
 
 View from the Learning Management System (LMS)
 **********************************************
 
 When a learner accesses the course, the Content Restrictions component will be displayed as a message indicating the
 restriction that applies to the content and the action the learner needs to take to access the content.
+
+Password Restriction
+--------------------
+
+When the Password restriction is enabled, the learner will see a message indicating that the content is restricted and will be prompted to enter the password to access the content.
+After entering the correct password, the content will be displayed. If the learner enters an incorrect password, a message will be displayed indicating that the password is incorrect.
+
+Here is an example of the message that the learner will see when the content is restricted by a password:
+
+   .. image:: https://github.com/eduNEXT/xblock-content-restrictions/assets/64440265/e6a14193-4370-4752-b82a-751c35afc8e5
+        :alt: Password restriction message
+
+When the learner enters the correct password, the content will be displayed. However, if the learner enters an incorrect password, a message will be displayed indicating that the password is incorrect.
+
+   .. image:: https://github.com/eduNEXT/xblock-content-restrictions/assets/64440265/f345f874-1a58-4f8d-ae12-7fa6087c6c8b
+        :alt: Incorrect password message
+
+As specified in the configuration, the learner will see the explanation text and the incorrect password explanation text.
 
 Experimenting with this XBlock in the Workbench
 ************************************************

--- a/content_restrictions/content_restrictions.py
+++ b/content_restrictions/content_restrictions.py
@@ -52,7 +52,7 @@ class XblockContentRestrictions(
     incorrect_password_explanation_text = String(
         display_name=_("Incorrect Password Explanatory Message"),
         help=_(
-            """This message will be shown when the learner enters an incorrect password."""
+            "This message will be shown when the learner enters an incorrect password."
         ),
         scope=Scope.settings,
         default=_("Incorrect password. Please try again."),
@@ -61,10 +61,10 @@ class XblockContentRestrictions(
     password = String(
         display_name=_("Password"),
         help=_(
-            """Learners will need to type this password to access the content of the xblock. If the learner"""
-            """ does not type the correct password, they will not have access to the content and will get an"""
-            """ explanatory message instead. If the password is changed after the learner has already accessed"""
-            """ the content, the learner will need to type the new password to access the content."""
+            "Learners will need to type this password to access the content of the xblock. If the learner"
+            " does not type the correct password, they will not have access to the content and will get an"
+            " explanatory message instead. If the password is changed after the learner has already accessed"
+            " the content, the learner will need to type the new password to access the content."
         ),
         scope=Scope.settings,
         default="",
@@ -73,8 +73,8 @@ class XblockContentRestrictions(
     user_provided_password = String(
         display_name=_("User Provided Password"),
         help=_(
-            """The password that the user has provided. This is used to check if the user has entered the"""
-            """ correct password."""
+            "The password that the user has provided. This is used to check if the user has entered the"
+            " correct password."
         ),
         scope=Scope.user_state,
         default="",

--- a/content_restrictions/content_restrictions.py
+++ b/content_restrictions/content_restrictions.py
@@ -157,7 +157,10 @@ class XblockContentRestrictions(
         fragment = Fragment()
         fragment.add_content(
             LOCAL_RESOURCE_LOADER.render_django_template(
-                "static/html/password_restriction.html", {"block": self}
+                f"static/html/{self.restriction_template}",
+                {
+                    "block": self,
+                }
             )
         )
         fragment.add_css(self.resource_string("static/css/content_restrictions.css"))
@@ -174,6 +177,17 @@ class XblockContentRestrictions(
         )
         fragment.initialize_js("XblockContentRestrictions")
         return fragment
+
+    @property
+    def restriction_template(self):
+        """
+        Get the current restriction template.
+
+        Returns:
+            str: The current restriction template.
+        """
+        if self.password_restriction:
+            return "password_restriction.html"
 
     @XBlock.json_handler
     def has_access_with_password(self, data, suffix=""):

--- a/content_restrictions/content_restrictions.py
+++ b/content_restrictions/content_restrictions.py
@@ -2,7 +2,7 @@
 import pkg_resources
 from django.utils import translation
 from xblock.core import XBlock
-from xblock.fields import Scope, String, Boolean
+from xblock.fields import Boolean, Scope, String
 from xblock.utils.resources import ResourceLoader
 from xblock.utils.studio_editable import StudioContainerWithNestedXBlocksMixin, StudioEditableXBlockMixin
 
@@ -188,11 +188,13 @@ class XblockContentRestrictions(
         """
         if self.password_restriction:
             return "password_restriction.html"
+        return "no_access.html"
 
     @XBlock.json_handler
-    def has_access_with_password(self, data, suffix=""):
+    def has_access_with_password(self, data, suffix=""):  # pylint: disable=unused-argument
         """
         Check if the user has the correct password.
+
         Args:
             data: The data sent by the client.
         Returns:

--- a/content_restrictions/static/css/content_restrictions.css
+++ b/content_restrictions/static/css/content_restrictions.css
@@ -1,9 +1,6 @@
 /* CSS for XblockContentRestrictions */
 
-.content_restrictions_block .count {
-    font-weight: bold;
-}
-
-.content_restrictions_block p {
-    cursor: pointer;
+.content_restrictions .password_explanation_text {
+    margin-top: 10px;
+    margin-bottom: 10px;
 }

--- a/content_restrictions/static/css/content_restrictions.css
+++ b/content_restrictions/static/css/content_restrictions.css
@@ -1,6 +1,8 @@
 /* CSS for XblockContentRestrictions */
 
-.content_restrictions .password_explanation_text {
+.content_restrictions .password_explanation_text,
+.incorrect_password_explanation_text
+ {
     margin-top: 10px;
     margin-bottom: 10px;
 }

--- a/content_restrictions/static/css/content_restrictions.css
+++ b/content_restrictions/static/css/content_restrictions.css
@@ -3,6 +3,5 @@
 .content_restrictions .password_explanation_text,
 .incorrect_password_explanation_text
  {
-    margin-top: 10px;
-    margin-bottom: 10px;
+    margin: 10px 0;
 }

--- a/content_restrictions/static/html/children.html
+++ b/content_restrictions/static/html/children.html
@@ -1,3 +1,6 @@
 <div class="content_restrictions_block">
-    {% for child_content in children_contents %} {{ child_content|safe }} {% endfor %}
+    {% for child_content in children_contents %}
+        {{ child_content|safe }}
+        <br>
+    {% endfor %}
 </div>

--- a/content_restrictions/static/html/children.html
+++ b/content_restrictions/static/html/children.html
@@ -2,6 +2,7 @@
     {% for child_content in children_contents %}
         {{ child_content|safe }}
         <br>
+        <hr>
     {% endfor %}
     <br>
 </div>

--- a/content_restrictions/static/html/children.html
+++ b/content_restrictions/static/html/children.html
@@ -3,4 +3,5 @@
         {{ child_content|safe }}
         <br>
     {% endfor %}
+    <br>
 </div>

--- a/content_restrictions/static/html/no_access.html
+++ b/content_restrictions/static/html/no_access.html
@@ -1,0 +1,6 @@
+
+<div class="content_restrictions_block">
+    <div class="content_restrictions">
+        This content is not restricted, however, you do not have access to it. Please contact the site administrator for more information.
+    </div>
+</div>

--- a/content_restrictions/static/html/password_restriction.html
+++ b/content_restrictions/static/html/password_restriction.html
@@ -5,5 +5,5 @@
     </div>
     <input type="password" class="password" name="password"/>
     <button class="submit-button">Submit</button>
-    <div class="incorrect-password-explanation-text"></div>
+    <div class="incorrect_password_explanation_text"></div>
 </div>

--- a/content_restrictions/static/html/password_restriction.html
+++ b/content_restrictions/static/html/password_restriction.html
@@ -1,0 +1,9 @@
+
+<div class="content_restrictions_block">
+    <div class="content_restrictions">
+        <div class="password_explanation_text"> {{ block.password_explanation_text }} </div>
+    </div>
+    <input type="password" class="password" name="password"/>
+    <button class="submit-button">Submit</button>
+    <div class="incorrect-password-explanation-text"></div>
+</div>

--- a/content_restrictions/static/js/src/content_restrictions.js
+++ b/content_restrictions/static/js/src/content_restrictions.js
@@ -12,7 +12,7 @@ function XblockContentRestrictions(runtime, element) {
                 window.location.reload(false);
             }
             else {
-                $(element).find('.incorrect-password-explanation-text').text(response.error_message);
+                $(element).find('.incorrect_password_explanation_text').text(response.error_message);
             }
         }
         );

--- a/content_restrictions/static/js/src/content_restrictions.js
+++ b/content_restrictions/static/js/src/content_restrictions.js
@@ -1,2 +1,20 @@
 /* Javascript for XblockContentRestrictions. */
-function XblockContentRestrictions(runtime, element) {}
+function XblockContentRestrictions(runtime, element) {
+
+    var handlerUrl = runtime.handlerUrl(element, 'has_access_with_password');
+
+    $(element).find('.submit-button').bind('click', function() {
+        var data = {
+            "password": $(element).find('input[name=password]').val(),
+        }
+        $.post(handlerUrl, JSON.stringify(data)).done(function(response) {
+            if (response.success) {
+                window.location.reload(false);
+            }
+            else {
+                $(element).find('.incorrect-password-explanation-text').text(response.error_message);
+            }
+        }
+        );
+    })
+}

--- a/tests/test_content_restrictions.py
+++ b/tests/test_content_restrictions.py
@@ -47,7 +47,7 @@ class TestXblockContentRestrictions(TestCase):
 
         self.assertEqual(
             fragment.content.replace('\n', '').replace(' ', ''),
-            '<divclass="content_restrictions_block"></div>',
+            '<divclass="content_restrictions_block"><br></div>',
         )
 
     def test_student_view_with_children(self):
@@ -62,7 +62,7 @@ class TestXblockContentRestrictions(TestCase):
 
         self.assertEqual(
             fragment.content.replace('\n', '').replace(' ', ''),
-            '<divclass="content_restrictions_block">MyXBlock:countisnow0</div>',
+            '<divclass="content_restrictions_block">MyXBlock:countisnow0<br><br></div>',
         )
 
 

--- a/tests/test_content_restrictions.py
+++ b/tests/test_content_restrictions.py
@@ -62,7 +62,7 @@ class TestXblockContentRestrictions(TestCase):
 
         self.assertEqual(
             fragment.content.replace('\n', '').replace(' ', ''),
-            '<divclass="content_restrictions_block">MyXBlock:countisnow0<br><br></div>',
+            '<divclass="content_restrictions_block">MyXBlock:countisnow0<br><hr><br></div>',
         )
 
 

--- a/tests/test_content_restrictions.py
+++ b/tests/test_content_restrictions.py
@@ -30,6 +30,11 @@ class TestXblockContentRestrictions(TestCase):
             field_data={},
             scope_ids=ScopeIds('1', '2', '3', '4'),
         )
+        self.block.password_restriction = False
+        self.block.password = ''
+        self.block.user_provided_password = ''
+        self.block.incorrect_password_explanation_text = 'Incorrect password'
+        self.block.password_explanation_text = 'Enter the password'
 
     def test_student_view_without_children(self):
         """Render the student view without children.
@@ -95,3 +100,57 @@ class TestXblockContentRestrictions(TestCase):
             fragment.content.replace('\n', '').replace(' ', ''),
             '',
         )
+
+    def test_password_restriction(self):
+        """Test the password restriction.
+
+        Expected result: True if the password is correct, False otherwise.
+        """
+        self.block.password_restriction = True
+        self.block.password = '1234'
+
+        self.assertFalse(self.block.has_access_to_content)
+
+        self.block.user_provided_password = '1234'
+
+        self.assertTrue(self.block.has_access_to_content)
+
+    def test_student_view_with_password_restriction(self):
+        """Render the student view with password restriction.
+
+        Expected result: the password template.
+        """
+        self.block.password_restriction = True
+        self.block.password = '1234'
+        self.block.user_provided_password = ''
+
+        fragment = self.block.student_view({})
+
+        self.assertEqual(
+            fragment.content.replace('\n', '').replace(' ', ''),
+            """
+            <div class="content_restrictions_block">
+                <div class="content_restrictions">
+                    <div class="password_explanation_text"> Enter the password </div>
+                </div>
+                <input type="password" class="password" name="password"/>
+                <button class="submit-button">Submit</button>
+                <div class="incorrect_password_explanation_text"></div>
+            </div>
+            """.replace('\n', '').replace(' ', ''),
+        )
+
+    def test_has_access_with_password(self):
+        """Test the has_access_with_password method.
+
+        Expected result: True if the password is correct, False otherwise.
+        """
+        self.block.password_restriction = True
+        self.block.password = '1234'
+        request = Mock(method='POST', body=b'{"password": "1234"}')
+
+        self.assertTrue(self.block.has_access_with_password(request).json['success'])
+
+        request = Mock(method='POST', body=b'{"password": "12345"}')
+
+        self.assertFalse(self.block.has_access_with_password(request).json['success'])


### PR DESCRIPTION
### Description
This PR adds the necessary implementation to block content by password for Students. Once the correct password is entered, the user will have access to the content. Otherwise, a view asking for a password will be shown.

### How to test
1. Configure this xblock in your course by adding it to your Advanced Module configuration: `content_restrictions`
2. Create a unit with this new component
3. Configure its children by adding them to the components' Author View
4. Configure the block with the necessary information
5. As a student, go to the LMS. A view will be shown based on your previous configurations